### PR TITLE
解决了当传入参数为中文时候，Invalid signature的错误

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -7,6 +7,6 @@ module.exports = {
 function crypt(text, algo) {
 	text = String(text || '');
 	algo = algo || 'sha256';
-
-	return crypto.createHash(algo).update(text).digest('hex');
+	
+  return crypto.createHash(algo).update(new Buffer(text)).digest('hex');
 }


### PR DESCRIPTION
当调用api传入中文参数的时候，会返回 { error_response: { code: 25, msg: 'Invalid signature' } } 的错误，修改helper.js这一行后，对中文生成签名可正常。
